### PR TITLE
Cats Spawning Survival

### DIFF
--- a/resources/assets/cats/entities/land/cat-female.json
+++ b/resources/assets/cats/entities/land/cat-female.json
@@ -518,9 +518,9 @@
                     "var": 0
                 },
                 "insideBlockCodes": [
-                    "air",
-                    "tallgrass-*",
-                    "snowlayer-1"
+                    "game:air",
+                    "game:tallgrass-*",
+                    "game:snowlayer-1"
                 ],
                 "minTemp": -15,
                 "maxTemp": 15,
@@ -544,9 +544,9 @@
                     "var": 0
                 },
                 "insideBlockCodes": [
-                    "air",
-                    "tallgrass-*",
-                    "snowlayer-1"
+                    "game:air",
+                    "game:tallgrass-*",
+                    "game:snowlayer-1"
                 ],
                 "minTemp": -15,
                 "maxTemp": 15,

--- a/resources/assets/cats/entities/land/cat-male.json
+++ b/resources/assets/cats/entities/land/cat-male.json
@@ -518,9 +518,9 @@
                     "var": 0
                 },
                 "insideBlockCodes": [
-                    "air",
-                    "tallgrass-*",
-                    "snowlayer-1"
+                    "game:air",
+                    "game:tallgrass-*",
+                    "game:snowlayer-1"
                 ],
                 "minTemp": -15,
                 "maxTemp": 15,
@@ -544,9 +544,9 @@
                     "var": 0
                 },
                 "insideBlockCodes": [
-                    "air",
-                    "tallgrass-*",
-                    "snowlayer-1"
+                    "game:air",
+                    "game:tallgrass-*",
+                    "game:snowlayer-1"
                 ],
                 "minTemp": -15,
                 "maxTemp": 15,


### PR DESCRIPTION
I managed to get cats to spawn in survival with tweaks to the insideBlockCode array.

Each string needs 'game:' prepended to it when trying to spawn inside vanilla blocks.

Meows for days!